### PR TITLE
feat: refactor config and flags for multi-container support

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -12,8 +12,8 @@ type (
 		Output    string
 		Debug     bool
 
-		Deployment string
-		Container  string
+		Deployment []string
+		Container  []string
 		Image      string
 
 		// kube config file

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/appleboy/deploy-k8s
 go 1.20
 
 require (
+	github.com/appleboy/com v0.1.7
 	github.com/joho/godotenv v1.5.1
 	github.com/mattn/go-isatty v0.0.19
 	github.com/rs/zerolog v1.29.1

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
+github.com/appleboy/com v0.1.7 h1:4lYTFNoMAAXGGIC8lDxVg/NY+1aXbYqfAWN05cZhd0M=
+github.com/appleboy/com v0.1.7/go.mod h1:JUK+oH0SXCLRH57pDMJx6VWVsm8CPdajalmRSWwamBE=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
@@ -38,7 +40,6 @@ github.com/go-openapi/jsonreference v0.20.2 h1:3sVjiK66+uXK/6oQ8xgcRKcFgQ5KXa2Kv
 github.com/go-openapi/jsonreference v0.20.2/go.mod h1:Bl1zwGIM8/wsvqjsOQLJ/SH+En5Ap4rVB5KVcIDZG2k=
 github.com/go-openapi/swag v0.22.3 h1:yMBqmnQ0gyZvEb/+KzuWZOXgllrXT4SADYbvDaXHv/g=
 github.com/go-openapi/swag v0.22.3/go.mod h1:UzaqsxGiab7freDnrUUra0MwWfN/q7tE4j+VcZ0yl14=
-github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 h1:p104kn46Q8WdvHunIJ9dAyjPVtrBPhSr3KT2yUst43I=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
@@ -73,7 +74,6 @@ github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeN
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
-github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 h1:K6RDEckDVWvDI9JAJYCmNdQXq6neHJOYx3V6jnqNEec=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -109,8 +109,6 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
-github.com/onsi/ginkgo/v2 v2.9.1 h1:zie5Ly042PD3bsCvsSOPvRnFwyo3rKe64TJlD6nu0mk=
-github.com/onsi/gomega v1.27.4 h1:Z2AnStgsdSayCMDiCU42qIz+HLqEPcgiOCXjAU/w+8E=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -214,7 +212,6 @@ golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBn
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
-golang.org/x/tools v0.7.0 h1:W4OVu8VVOaIO0yzWMNdepAulS7YfoS3Zabrm8DOXXU4=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/main.go
+++ b/main.go
@@ -84,12 +84,12 @@ func main() {
 			Usage:   "kubernetes namespace",
 			EnvVars: []string{"PLUGIN_NAMESPACE", "INPUT_NAMESPACE"},
 		},
-		&cli.StringFlag{
+		&cli.StringSliceFlag{
 			Name:    "deployment",
 			Usage:   "kubernetes deployment name",
 			EnvVars: []string{"PLUGIN_DEPLOYMENT", "INPUT_DEPLOYMENT"},
 		},
-		&cli.StringFlag{
+		&cli.StringSliceFlag{
 			Name:    "container",
 			Usage:   "kubernetes deployment container name",
 			EnvVars: []string{"PLUGIN_CONTAINER", "INPUT_CONTAINER"},
@@ -156,8 +156,8 @@ func run(c *cli.Context) error {
 			SkipTLS:      c.Bool("skip-tls"),
 			CaCert:       c.String("ca-cert"),
 			Namespace:    c.String("namespace"),
-			Deployment:   c.String("deployment"),
-			Container:    c.String("container"),
+			Deployment:   c.StringSlice("deployment"),
+			Container:    c.StringSlice("container"),
 			Image:        c.String("image"),
 			ProxyURL:     c.String("proxy-url"),
 			Templates:    c.StringSlice("templates"),

--- a/testdata/configmap.yaml
+++ b/testdata/configmap.yaml
@@ -1,7 +1,16 @@
 kind: ConfigMap
 apiVersion: v1
 metadata:
-  name: {{ .envs.app_name }}
+  name: {{ .envs.deploy_nginx_01 }}
   namespace: {{ .envs.app_namespace }}
   labels:
-    app: {{ .envs.app_name }}
+    app: {{ .envs.deploy_nginx_01 }}
+
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: {{ .envs.deploy_nginx_02 }}
+  namespace: {{ .envs.app_namespace }}
+  labels:
+    app: {{ .envs.deploy_nginx_02 }}

--- a/testdata/deployment.yaml
+++ b/testdata/deployment.yaml
@@ -1,23 +1,23 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .envs.app_name }}
+  name: {{ .envs.deploy_nginx_01 }}
   namespace: {{ .envs.app_namespace }}
   labels:
-    app: {{ .envs.app_name }}
+    app: {{ .envs.deploy_nginx_01 }}
 spec:
   selector:
     matchLabels:
-      app: {{ .envs.app_name }}
+      app: {{ .envs.deploy_nginx_01 }}
   template:
     metadata:
-      name: {{ .envs.app_name }}
+      name: {{ .envs.deploy_nginx_01 }}
       labels:
-        app: {{ .envs.app_name }}
+        app: {{ .envs.deploy_nginx_01 }}
     spec:
       containers:
-        - name: {{ .envs.app_name }}
-          image: nginx:latest
+        - name: {{ .envs.deploy_nginx_01 }}
+          image: nginx:1.25.0
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -34,14 +34,63 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .envs.app_name }}
+  name: {{ .envs.deploy_nginx_01 }}
   namespace: {{ .envs.app_namespace }}
   labels:
-    app: {{ .envs.app_name }}
+    app: {{ .envs.deploy_nginx_01 }}
 spec:
   ports:
     - nodePort: 30000
       port: 80
   selector:
-    app: {{ .envs.app_name }}
+    app: {{ .envs.deploy_nginx_01 }}
+  type: NodePort
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .envs.deploy_nginx_02 }}
+  namespace: {{ .envs.app_namespace }}
+  labels:
+    app: {{ .envs.deploy_nginx_02 }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ .envs.deploy_nginx_02 }}
+  template:
+    metadata:
+      name: {{ .envs.deploy_nginx_02 }}
+      labels:
+        app: {{ .envs.deploy_nginx_02 }}
+    spec:
+      containers:
+        - name: {{ .envs.deploy_nginx_02 }}
+          image: nginx:1.24.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 80
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "250m"
+            limits:
+              memory: "128Mi"
+              cpu: "500m"
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .envs.deploy_nginx_02 }}
+  namespace: {{ .envs.app_namespace }}
+  labels:
+    app: {{ .envs.deploy_nginx_02 }}
+spec:
+  ports:
+    - nodePort: 30001
+      port: 80
+  selector:
+    app: {{ .envs.deploy_nginx_02 }}
   type: NodePort


### PR DESCRIPTION
- Change Deployment and Container fields in config.go to slices
- Add github.com/appleboy/com v0.1.7 to go.mod
- Replace cli.StringFlag with cli.StringSliceFlag in main.go
- Update run function to use StringSlice instead of String in main.go
- Import "github.com/appleboy/com/array" in plugin.go
- Modify UpdateContainer function to support multiple deployments and containers
- Update testdata files with new deployment and configmap configurations